### PR TITLE
Upgrade to Elm version 0.18 simply by running elm-upgrade

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -1,5 +1,5 @@
 {
-    "version": "3.1.1",
+    "version": "3.1.2",
     "summary": "Library for working with matrices/grids",
     "repository": "https://github.com/chendrix/elm-matrix.git",
     "license": "MIT",
@@ -12,10 +12,10 @@
         "Matrix.Random"
     ],
     "dependencies": {
-        "elm-community/elm-check": "1.0.0 <= v < 2.0.0",
-        "elm-community/shrink": "1.0.0 <= v < 2.0.0",
-        "elm-lang/core": "4.0.0 <= v < 5.0.0",
-        "elm-lang/html": "1.0.0 <= v < 2.0.0"
+        "elm-community/elm-check": "2.0.1 <= v < 3.0.0",
+        "elm-community/shrink": "2.0.0 <= v < 3.0.0",
+        "elm-lang/core": "5.0.0 <= v < 6.0.0",
+        "elm-lang/html": "2.0.0 <= v < 3.0.0"
     },
-    "elm-version": "0.17.0 <= v < 0.18.0"
+    "elm-version": "0.18.0 <= v < 0.19.0"
 }

--- a/src/Matrix.elm
+++ b/src/Matrix.elm
@@ -32,21 +32,25 @@ import Array
 import List
 import Maybe exposing (..)
 
+
 {-| An ordered collection of elements, all of a particular type, arranged into `m` rows and `n` columns.
 
 -}
-type alias Matrix a = Array.Array (Array.Array a)
+type alias Matrix a =
+    Array.Array (Array.Array a)
 
 
 {-| A representation of a row number and a column number, used to locate and access elements in a matrix.
 -}
-type alias Location = (Int, Int)
+type alias Location =
+    ( Int, Int )
 
 
 {-| Turn two integers into a location
 -}
 loc : Int -> Int -> Location
-loc = (,)
+loc =
+    (,)
 
 
 {-| Extract the row number from a location
@@ -55,7 +59,8 @@ loc = (,)
 
 -}
 row : Location -> Int
-row = fst
+row =
+    Tuple.first
 
 
 {-| Extract the col number from a location
@@ -64,7 +69,8 @@ row = fst
 
 -}
 col : Location -> Int
-col = snd
+col =
+    Tuple.second
 
 
 {-| Create a square matrix of a certain size
@@ -73,7 +79,8 @@ col = snd
                             H H
 -}
 square : Int -> (Location -> a) -> Matrix a
-square size = matrix size size
+square size =
+    matrix size size
 
 
 {-| Initialize a new matrix of size `m x n`.
@@ -91,9 +98,11 @@ will give back the matrix
 -}
 matrix : Int -> Int -> (Location -> a) -> Matrix a
 matrix numRows numCols f =
-  Array.initialize numRows (
-    \row -> Array.initialize numCols (
-      \col -> f (loc row col)))
+    Array.initialize numRows
+        (\row ->
+            Array.initialize numCols
+                (\col -> f (loc row col))
+        )
 
 
 {-| Apply the function to every element in the matrix
@@ -102,7 +111,7 @@ matrix numRows numCols f =
 -}
 map : (a -> b) -> Matrix a -> Matrix b
 map f m =
-  Array.map (Array.map f) m
+    Array.map (Array.map f) m
 
 
 {-| Apply the function to every element in the list, where the first function argument
@@ -119,12 +128,15 @@ is the location of the element.
 -}
 mapWithLocation : (Location -> a -> b) -> Matrix a -> Matrix b
 mapWithLocation f m =
-  Array.indexedMap (
-    \rowNum row -> Array.indexedMap (
-      \colNum element ->
-        f (loc rowNum colNum) element
-    ) row
-  ) m
+    Array.indexedMap
+        (\rowNum row ->
+            Array.indexedMap
+                (\colNum element ->
+                    f (loc rowNum colNum) element
+                )
+                row
+        )
+        m
 
 
 {-| Convert a matrix to a list of lists
@@ -134,8 +146,8 @@ mapWithLocation f m =
 -}
 toList : Matrix a -> List (List a)
 toList m =
-  Array.map Array.toList m
-  |> Array.toList
+    Array.map Array.toList m
+        |> Array.toList
 
 
 {-| Convert a list of lists into a matrix
@@ -144,8 +156,8 @@ toList m =
 -}
 fromList : List (List a) -> Matrix a
 fromList l =
-  List.map Array.fromList l
-  |> Array.fromList
+    List.map Array.fromList l
+        |> Array.fromList
 
 
 {-| Convert a matrix to a single list
@@ -157,7 +169,7 @@ fromList l =
 -}
 flatten : Matrix a -> List a
 flatten m =
-  List.concat <| toList m
+    List.concat <| toList m
 
 
 {-| Get the element at a particular location
@@ -168,7 +180,7 @@ flatten m =
 -}
 get : Location -> Matrix a -> Maybe a
 get location m =
-  Array.get (row location) m `andThen` Array.get (col location)
+    Array.get (row location) m |> andThen (Array.get (col location))
 
 
 {-| Set the element at a particular location
@@ -179,7 +191,7 @@ get location m =
 -}
 set : Location -> a -> Matrix a -> Matrix a
 set location value m =
-  update location (always value) m
+    update location (always value) m
 
 
 {-| Update the element at a particular location using the current value
@@ -187,31 +199,31 @@ set location value m =
 -}
 update : Location -> (a -> a) -> Matrix a -> Matrix a
 update location f m =
-  get location m
-  |> Maybe.map (
-    \current ->
+    get location m
+        |> Maybe.map
+            (\current ->
+                Array.get (row location) m
+                    |> Maybe.map
+                        (\oldRow ->
+                            Array.set (col location) (f current) oldRow
+                                |> (\newRow -> Array.set (row location) newRow m)
+                        )
+                    |> Maybe.withDefault m
+            )
+        |> Maybe.withDefault m
 
-      Array.get (row location) m
-      |> Maybe.map (
-          \oldRow ->
-            Array.set (col location) (f current) oldRow
-            |> (\newRow -> Array.set (row location) newRow m)
-      )
-      |> Maybe.withDefault m
-  )
-  |> Maybe.withDefault m
 
 {-| Get the number of columns in a matrix
 -}
 colCount : Matrix a -> Int
 colCount m =
-  Array.get 0 m
-  |> Maybe.map Array.length
-  |> Maybe.withDefault 0
+    Array.get 0 m
+        |> Maybe.map Array.length
+        |> Maybe.withDefault 0
 
 
 {-| Get the number of rows in a matrix
 -}
 rowCount : Matrix a -> Int
 rowCount m =
-  Array.length m
+    Array.length m

--- a/src/Matrix/Random.elm
+++ b/src/Matrix/Random.elm
@@ -20,19 +20,24 @@ The example above will generate you a matrix anywhere between 1-4 rows, 2-5 colu
 -}
 matrix : Generator Int -> Generator Int -> Generator a -> Generator (Matrix a)
 matrix widthGenerator heightGenerator elementGenerator =
-  widthGenerator `andThen` \width ->
-    heightGenerator `andThen` \height ->
-      let
-        rowGenerator =
-          list width elementGenerator
-          |> map Array.fromList
+    widthGenerator
+        |> andThen
+            (\width ->
+                heightGenerator
+                    |> andThen
+                        (\height ->
+                            let
+                                rowGenerator =
+                                    list width elementGenerator
+                                        |> map Array.fromList
 
-        matrixAsArrayGenerator =
-          list height rowGenerator
-          |> map Array.fromList
-
-      in
-        matrixAsArrayGenerator
+                                matrixAsArrayGenerator =
+                                    list height rowGenerator
+                                        |> map Array.fromList
+                            in
+                                matrixAsArrayGenerator
+                        )
+            )
 
 
 {-| Generate a matrix of a random width and height, but whose elements are generated via a function given the location of that element in the matrix.
@@ -53,8 +58,11 @@ In the example above, if it makes a 4x2 matrix, it will be
     F F F F
 
 -}
-matrixUsing  : Generator Int -> Generator Int -> (Location -> a) -> Generator (Matrix a)
-matrixUsing  widthGenerator heightGenerator f =
-  map2 (\width height ->
-    Matrix.matrix width height f
-  ) widthGenerator heightGenerator
+matrixUsing : Generator Int -> Generator Int -> (Location -> a) -> Generator (Matrix a)
+matrixUsing widthGenerator heightGenerator f =
+    map2
+        (\width height ->
+            Matrix.matrix width height f
+        )
+        widthGenerator
+        heightGenerator

--- a/test/Check/Producer/Matrix.elm
+++ b/test/Check/Producer/Matrix.elm
@@ -3,30 +3,38 @@ module Check.Producer.Matrix exposing (..)
 import Check.Producer exposing (..)
 import Shrink.Matrix as S
 import Shrink exposing (noShrink)
-
 import Matrix.Random
 import Matrix exposing (Matrix, Location)
 
+
 matrix : Producer a -> Producer (Matrix a)
 matrix v =
-  let
-    width = rangeInt 0 50
-    height = rangeInt 0 50
-  in
-    Producer
-      (Matrix.Random.matrix width.generator height.generator v.generator)
-      (S.matrix v.shrinker)
+    let
+        width =
+            rangeInt 0 50
+
+        height =
+            rangeInt 0 50
+    in
+        Producer
+            (Matrix.Random.matrix width.generator height.generator v.generator)
+            (S.matrix v.shrinker)
+
 
 matrixUsing : (Location -> a) -> Producer (Matrix a)
 matrixUsing f =
-  let
-    width = rangeInt 0 50
-    height = rangeInt 0 50
-  in
-    Producer
-      (Matrix.Random.matrixUsing width.generator height.generator f)
-      (noShrink)
+    let
+        width =
+            rangeInt 0 50
+
+        height =
+            rangeInt 0 50
+    in
+        Producer
+            (Matrix.Random.matrixUsing width.generator height.generator f)
+            (noShrink)
+
 
 location : Producer Location
 location =
-  tuple (rangeInt -10 50, rangeInt -10 50)
+    tuple ( rangeInt -10 50, rangeInt -10 50 )

--- a/test/Check/Runner/Browser.elm
+++ b/test/Check/Runner/Browser.elm
@@ -1,7 +1,9 @@
-module Check.Runner.Browser exposing
-  ( display
-  , displayVerbose
-  )
+module Check.Runner.Browser
+    exposing
+        ( display
+        , displayVerbose
+        )
+
 {-| Browser test runner for elm-check. This module provides functions to
 run and visualize tests in the browser.
 
@@ -10,53 +12,67 @@ run and visualize tests in the browser.
 
 -}
 
-import Check exposing (Evidence (..), UnitEvidence, SuccessOptions, FailureOptions)
+import Check exposing (Evidence(..), UnitEvidence, SuccessOptions, FailureOptions)
 import Html exposing (Html, Attribute, div, text, ul, ol, li)
 import Html.Attributes exposing (style)
 import List
 
 
-(:::) = (,)
+(:::) =
+    (,)
 
-type alias Style = List (String, String)
+
+type alias Style =
+    List ( String, String )
 
 
-pomegranate     = "#c0392b"
-backgroundBrown = "#DDCCA1"
-midnightBlue    = "#2c3e50"
-nephritis       = "#27ae60"
+pomegranate =
+    "#c0392b"
+
+
+backgroundBrown =
+    "#DDCCA1"
+
+
+midnightBlue =
+    "#2c3e50"
+
+
+nephritis =
+    "#27ae60"
+
 
 toColor : Bool -> String
 toColor b =
-  if b
-  then
-    nephritis
-  else
-    pomegranate
+    if b then
+        nephritis
+    else
+        pomegranate
+
 
 suiteStyle : Bool -> Style
 suiteStyle b =
-  [ "display"          ::: "flex"
-  , "flex-direction"   ::: "column"
-  , "color"            ::: toColor b
-  ]
-
+    [ "display" ::: "flex"
+    , "flex-direction" ::: "column"
+    , "color" ::: toColor b
+    ]
 
 
 displayStyle : Style
 displayStyle =
-  [ "width"             ::: "100vw"
-  , "min-height"        ::: "100vh"
-  , "background-color"  ::: backgroundBrown
-  ]
+    [ "width" ::: "100vw"
+    , "min-height" ::: "100vh"
+    , "background-color" ::: backgroundBrown
+    ]
+
 
 {-| Display test results in the browser.
 -}
 display : Evidence -> Html msg
 display evidence =
-  div
-    [ style displayStyle ]
-    [ display' False evidence ]
+    div
+        [ style displayStyle ]
+        [ display_ False evidence ]
 
 
 {-| Verbose version of `display`. Contains additional information
@@ -64,111 +80,132 @@ about the test results.
 -}
 displayVerbose : Evidence -> Html msg
 displayVerbose evidence =
-  div
-    [ style displayStyle ]
-    [ display' True evidence]
+    div
+        [ style displayStyle ]
+        [ display_ True evidence ]
 
-display' : Bool -> Evidence -> Html msg
-display' b evidence = case evidence of
-  Unit unitEvidence ->
-    displayUnit b unitEvidence
-  Multiple name evidences ->
-    displaySuite b name evidences
+
+display_ : Bool -> Evidence -> Html msg
+display_ b evidence =
+    case evidence of
+        Unit unitEvidence ->
+            displayUnit b unitEvidence
+
+        Multiple name evidences ->
+            displaySuite b name evidences
+
 
 displaySuite : Bool -> String -> List Evidence -> Html msg
 displaySuite b name evidences =
-  li
-    [ style (suiteStyle (areOk evidences)) ]
-    [ text ("Suite: " ++ name)
-    , ol
-        []
-        (List.map (display' b) evidences)
-    ]
+    li
+        [ style (suiteStyle (areOk evidences)) ]
+        [ text ("Suite: " ++ name)
+        , ol
+            []
+            (List.map (display_ b) evidences)
+        ]
 
 
 isOk : Evidence -> Bool
-isOk evidence = case evidence of
-  Unit unitEvidence -> case unitEvidence of
-    Ok _ -> True
-    _ -> False
-  Multiple _ evidences ->
-    areOk evidences
+isOk evidence =
+    case evidence of
+        Unit unitEvidence ->
+            case unitEvidence of
+                Ok _ ->
+                    True
+
+                _ ->
+                    False
+
+        Multiple _ evidences ->
+            areOk evidences
 
 
 areOk : List Evidence -> Bool
 areOk evidences =
-  List.all ((==) True) (List.map isOk evidences)
+    List.all ((==) True) (List.map isOk evidences)
 
 
 unitStyle : Bool -> Style
 unitStyle b =
-  [ "color"            ::: toColor b
-  , "margin-bottom"    ::: "5px"
-  , "margin-top"       ::: "10px"
-  ]
+    [ "color" ::: toColor b
+    , "margin-bottom" ::: "5px"
+    , "margin-top" ::: "10px"
+    ]
 
 
 unitInnerStyle : Style
 unitInnerStyle =
-  [ "color" ::: midnightBlue ]
+    [ "color" ::: midnightBlue ]
+
 
 displayUnit : Bool -> UnitEvidence -> Html msg
-displayUnit b unitEvidence = case unitEvidence of
-  Ok options ->
-    li
-      [ style (unitStyle True) ]
-      [ text (successMessage options) ]
+displayUnit b unitEvidence =
+    case unitEvidence of
+        Ok options ->
+            li
+                [ style (unitStyle True) ]
+                [ text (successMessage options) ]
 
-  Err options ->
-    let
-        essentialParts =
-          [ li
-              []
-              [ text ("Counter example: " ++ options.counterExample) ]
-          , li
-              []
-              [ text ("Actual: " ++ options.actual) ]
-          , li
-              []
-              [ text ("Expected: " ++ options.expected)]
-
-          ]
-
-        verboseParts =
-          if not b then []
-          else
-            [ li
-                []
-                [ text ("Seed: " ++ (toString options.seed)) ]
-            , li
-                []
-                [ text ("Number of shrinking operations performed: " ++ (toString options.numberOfShrinks)) ]
-            , li
-                []
-                [ text "Before shrinking: "
-                , ul
-                    []
+        Err options ->
+            let
+                essentialParts =
                     [ li
                         []
-                        [ text ("Counter example: " ++ options.original.counterExample) ]
+                        [ text ("Counter example: " ++ options.counterExample) ]
                     , li
                         []
-                        [ text ("Actual: " ++ options.original.actual) ]
+                        [ text ("Actual: " ++ options.actual) ]
                     , li
                         []
-                        [ text ("Expected: " ++ options.original.expected) ]
+                        [ text ("Expected: " ++ options.expected) ]
                     ]
-                ]
-            ]
-    in
-        li
-          [ style (unitStyle False) ]
-          [ text (options.name ++ " FAILED after " ++ (toString options.numberOfChecks) ++ " check"++ (if options.numberOfChecks == 1 then "" else "s") ++ "!")
-          , ul
-              [ style unitInnerStyle ]
-              (essentialParts ++ verboseParts)
-          ]
+
+                verboseParts =
+                    if not b then
+                        []
+                    else
+                        [ li
+                            []
+                            [ text ("Seed: " ++ (toString options.seed)) ]
+                        , li
+                            []
+                            [ text ("Number of shrinking operations performed: " ++ (toString options.numberOfShrinks)) ]
+                        , li
+                            []
+                            [ text "Before shrinking: "
+                            , ul
+                                []
+                                [ li
+                                    []
+                                    [ text ("Counter example: " ++ options.original.counterExample) ]
+                                , li
+                                    []
+                                    [ text ("Actual: " ++ options.original.actual) ]
+                                , li
+                                    []
+                                    [ text ("Expected: " ++ options.original.expected) ]
+                                ]
+                            ]
+                        ]
+            in
+                li
+                    [ style (unitStyle False) ]
+                    [ text
+                        (options.name ++ " FAILED after " ++ (toString options.numberOfChecks) ++ " check"
+                            ++ (if options.numberOfChecks == 1 then
+                                    ""
+                                else
+                                    "s"
+                               )
+                            ++ "!"
+                        )
+                    , ul
+                        [ style unitInnerStyle ]
+                        (essentialParts ++ verboseParts)
+                    ]
+
 
 successMessage : SuccessOptions -> String
-successMessage {name, seed, numberOfChecks} =
-  name ++ " passed after " ++ (toString numberOfChecks) ++ " checks."
+successMessage { name, seed, numberOfChecks } =
+    name ++ " passed after " ++ (toString numberOfChecks) ++ " checks."

--- a/test/MatrixTest.elm
+++ b/test/MatrixTest.elm
@@ -5,55 +5,72 @@ import Check.Producer exposing (..)
 import Check.Producer.Matrix exposing (..)
 import Maybe as M exposing (..)
 import Debug
-
 import Matrix
 
-tests = suite "Matrix Test Suite"
-  [ claim_map_with_location_is_idempotent
-  , claim_get_and_set_are_inverses
-  , claim_to_list_and_from_list_are_inverses
-  , claim_square_makes_the_right_sized_matrix
-  ]
+
+tests =
+    suite "Matrix Test Suite"
+        [ claim_map_with_location_is_idempotent
+        , claim_get_and_set_are_inverses
+        , claim_to_list_and_from_list_are_inverses
+        , claim_square_makes_the_right_sized_matrix
+        ]
+
 
 claim_map_with_location_is_idempotent =
-  claim
-    "Creating a new map and generating a map from locations is the same"
-  `that`
-    (\matrix -> Matrix.mapWithLocation (\loc _ -> loc) matrix)
-  `is`
-    (identity)
-  `for`
-    matrixUsing identity
+    for
+        (is
+            (that
+                (claim
+                    "Creating a new map and generating a map from locations is the same"
+                )
+                (\matrix -> Matrix.mapWithLocation (\loc _ -> loc) matrix)
+            )
+            (identity)
+        )
+        (matrixUsing identity)
+
 
 claim_get_and_set_are_inverses =
-  claim
-    "Get and set are inverses"
-  `that`
-    (\(location, matrix, value) -> Matrix.set location value matrix |> Matrix.get location)
-  `is`
-    (\(location, matrix, value) -> Matrix.get location matrix |> M.map (always value))
-  `for`
-    tuple3 (location, matrix int, int)
+    for
+        (is
+            (that
+                (claim
+                    "Get and set are inverses"
+                )
+                (\( location, matrix, value ) -> Matrix.set location value matrix |> Matrix.get location)
+            )
+            (\( location, matrix, value ) -> Matrix.get location matrix |> M.map (always value))
+        )
+        (tuple3 ( location, matrix int, int ))
+
 
 claim_square_makes_the_right_sized_matrix =
-  claim
-    "Square makes the right sized matrix"
-  `true`
-    (\size ->
-      let
-        matrix = Matrix.square size identity
-      in
-        Matrix.rowCount matrix == size && Matrix.colCount matrix == size
-    )
-  `for`
-    rangeInt 0 50
+    for
+        (true
+            (claim
+                "Square makes the right sized matrix"
+            )
+            (\size ->
+                let
+                    matrix =
+                        Matrix.square size identity
+                in
+                    Matrix.rowCount matrix == size && Matrix.colCount matrix == size
+            )
+        )
+        (rangeInt 0 50)
+
 
 claim_to_list_and_from_list_are_inverses =
-  claim
-    "toList and fromList are inverses"
-  `that`
-    (Matrix.toList >> Matrix.fromList)
-  `is`
-    identity
-  `for`
-    matrix float
+    for
+        (is
+            (that
+                (claim
+                    "toList and fromList are inverses"
+                )
+                (Matrix.toList >> Matrix.fromList)
+            )
+            identity
+        )
+        (matrix float)

--- a/test/Shrink/Matrix.elm
+++ b/test/Shrink/Matrix.elm
@@ -3,5 +3,7 @@ module Shrink.Matrix exposing (..)
 import Shrink exposing (Shrinker, array)
 import Matrix exposing (Matrix)
 
+
 matrix : Shrinker a -> Shrinker (Matrix a)
-matrix = array >> array
+matrix =
+    array >> array

--- a/test/TestRunner.elm
+++ b/test/TestRunner.elm
@@ -1,14 +1,21 @@
+module Main exposing (..)
+
 import Check exposing (..)
 import Check.Runner.Browser exposing (display)
-
 import MatrixTest
 
+
 tests : Claim
-tests = suite "Matrix Tests"
+tests =
+    suite "Matrix Tests"
         [ MatrixTest.tests
         ]
 
-result : Evidence
-result = quickCheck tests
 
-main = display result
+result : Evidence
+result =
+    quickCheck tests
+
+
+main =
+    display result


### PR DESCRIPTION
I ran `elm-upgrade` successfully, then ran `make test/open` which passed.

I then ran `elm-package bump` and it updated to the next patch revision from **3.1.1** to **3.1.2**.

It would help me out a lot if you could merge this so that I can keep my game development going more easily.

Thanks in advance.

Scott -- oldfartdeveloper

P.S.: The vast majority of changes are caused by **elm-format**.  I originally wanted **elm-format** to use 2 spaces per tab (like you, but it seems that the decision has been made to use 4 spaces per tab instead.  After being furious about it for a while, I finally came to the conclusion that, with the way that **elm-format** aggressively wraps lines (which I don't have a problem with), the tab space indenting just doesn't make a big difference.

Anyways, if you just.can't.do.it, ping me back and I'll make specific changes and save your formatting.

